### PR TITLE
Update typings to extend basic HTML attributes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,7 +24,7 @@ declare namespace FlexboxReact {
     type JustifyContent = 'center' | 'flex-end' | 'flex-start' | 'space-around' | 'space-between';
 
     // <Flexbox />
-    interface FlexboxProps {
+    interface FlexboxProps extends React.HTMLAttributes<HTMLElement> {
         alignContent?: AlignContent;
         alignItems?: AlignItems;
         alignSelf?: AlignItems;


### PR DESCRIPTION
* This minor change allows TypeScript consumers to attach HTML attributes and properties (like `onClick`) to `Flexbox` components